### PR TITLE
Fix themes.sample.blog: Call `page.path` instead of `page.link` for a.href in blog_macros.html

### DIFF
--- a/miyadaiku/themes/sample/blog/templates/blog_macros.html
+++ b/miyadaiku/themes/sample/blog/templates/blog_macros.html
@@ -3,9 +3,9 @@
   <div class="index-pagination">
     {% if cur_page != 1 %}
       <a class="index-pagination-button"
-         href="{{page.link(group_value=group_value, npage=1)}}">⇤</a>
+         href="{{page.path(group_value=group_value, npage=1)}}">⇤</a>
       <a class="index-pagination-button"
-         href="{{page.link(group_value=group_value, npage=cur_page-1)}}">←</a>
+         href="{{page.path(group_value=group_value, npage=cur_page-1)}}">←</a>
     {% else %}
       <span class="index-pagination-button index-pagination-button-disabled">⇤</span>
       <span class="index-pagination-button index-pagination-button-disabled">←</span>


### PR DESCRIPTION
Content object method `page.link` generates a HTML anchor tag.

For HTML `a.href` attribute value, `page.path` should be used instead of `page.link`.
