### PR TITLE
Add `strip_directory_index` feature to remove a filename from generated URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.db
+_file_cache.*
 *.dll
 *.exe
 *.o

--- a/miyadaiku/__init__.py
+++ b/miyadaiku/__init__.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 import posixpath
 from pathlib import Path
+import urllib.parse
 from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
 import importlib_resources
@@ -177,6 +178,16 @@ def parse_dir(path: str, cwd: PathTuple) -> PathTuple:
         path = posixpath.join(curdir, path)
 
     return to_pathtuple(path)
+
+
+def strip_directory_index(path: str, directory_index: str):
+    parsed = urllib.parse.urlparse(path)
+
+    if posixpath.basename(parsed.path) == directory_index:
+        parsed = parsed._replace(path=posixpath.dirname(parsed.path) + "/")
+        path = urllib.parse.urlunparse(parsed)
+
+    return path
 
 
 class OutputInfo(NamedTuple):

--- a/miyadaiku/__init__.py
+++ b/miyadaiku/__init__.py
@@ -184,7 +184,11 @@ def strip_directory_index(path: str, directory_index: str):
     parsed = urllib.parse.urlparse(path)
 
     if posixpath.basename(parsed.path) == directory_index:
-        parsed = parsed._replace(path=posixpath.dirname(parsed.path) + "/")
+        new_path = posixpath.dirname(parsed.path)
+        if len(new_path) != 0 and new_path != '/':
+            new_path += "/"
+
+        parsed = parsed._replace(path=new_path)
         path = urllib.parse.urlunparse(parsed)
 
     return path

--- a/miyadaiku/config.py
+++ b/miyadaiku/config.py
@@ -69,6 +69,8 @@ DEFAULTS = dict(
     generate_metadata_file=False,
     has_jinja=False,
     short_header_id=False,
+    strip_directory_index=False,
+    directory_index="index.html",
 )
 
 

--- a/miyadaiku/config.py
+++ b/miyadaiku/config.py
@@ -70,7 +70,6 @@ DEFAULTS = dict(
     has_jinja=False,
     short_header_id=False,
     strip_directory_index=False,
-    directory_index="index.html",
 )
 
 

--- a/miyadaiku/contents.py
+++ b/miyadaiku/contents.py
@@ -250,6 +250,14 @@ date: {datestr}
                 path = posixpath.join(*self.src.contentpath[0], path)
         else:
             path = self.build_output_path(ctx, pageargs)
+
+        if self.get_metadata(ctx.site, "strip_directory_index"):
+            directory_index = self.get_metadata(ctx.site, "directory_index")
+            parsed = urllib.parse.urlparse(path)
+            if posixpath.basename(parsed.path) == directory_index:
+                parsed = parsed._replace(path=posixpath.dirname(parsed.path) + "/")
+                path = urllib.parse.urlunparse(parsed)
+
         return cast(str, urllib.parse.urljoin(site_url, path))
 
     def eval_body(self, ctx: context.OutputContext, propname: str) -> str:

--- a/miyadaiku/contents.py
+++ b/miyadaiku/contents.py
@@ -16,7 +16,7 @@ import pytz
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString
 
-from miyadaiku import METADATA_FILE_SUFFIX, ContentSrc, PathTuple, repr_contentpath
+from miyadaiku import METADATA_FILE_SUFFIX, ContentSrc, PathTuple, repr_contentpath, strip_directory_index
 
 from . import config, context, extend, site
 from .jinjaenv import safepath
@@ -253,10 +253,7 @@ date: {datestr}
 
         if self.get_metadata(ctx.site, "strip_directory_index"):
             directory_index = self.get_metadata(ctx.site, "directory_index")
-            parsed = urllib.parse.urlparse(path)
-            if posixpath.basename(parsed.path) == directory_index:
-                parsed = parsed._replace(path=posixpath.dirname(parsed.path) + "/")
-                path = urllib.parse.urlunparse(parsed)
+            path = strip_directory_index(path, directory_index)
 
         return cast(str, urllib.parse.urljoin(site_url, path))
 

--- a/miyadaiku/contents.py
+++ b/miyadaiku/contents.py
@@ -251,9 +251,9 @@ date: {datestr}
         else:
             path = self.build_output_path(ctx, pageargs)
 
-        if self.get_metadata(ctx.site, "strip_directory_index"):
-            directory_index = self.get_metadata(ctx.site, "directory_index")
-            path = strip_directory_index(path, directory_index)
+            if self.get_metadata(ctx.site, "strip_directory_index"):
+                directory_index = self.get_metadata(ctx.site, "directory_index")
+                path = strip_directory_index(path, directory_index)
 
         return cast(str, urllib.parse.urljoin(site_url, path))
 

--- a/miyadaiku/contents.py
+++ b/miyadaiku/contents.py
@@ -251,8 +251,9 @@ date: {datestr}
         else:
             path = self.build_output_path(ctx, pageargs)
 
-            if self.get_metadata(ctx.site, "strip_directory_index"):
-                directory_index = self.get_metadata(ctx.site, "directory_index")
+            # strip_directory_index is not applied if canonical_url is specified
+            directory_index = self.get_metadata(ctx.site, "strip_directory_index")
+            if directory_index: # skip if falsy value (false, empty string, etc.)
                 path = strip_directory_index(path, directory_index)
 
         return cast(str, urllib.parse.urljoin(site_url, path))

--- a/samples/strip_directory_index/.gitignore
+++ b/samples/strip_directory_index/.gitignore
@@ -1,0 +1,1 @@
+/outputs/

--- a/samples/strip_directory_index/config.yml
+++ b/samples/strip_directory_index/config.yml
@@ -1,4 +1,3 @@
-strip_directory_index: true
-directory_index: index.html
+strip_directory_index: index.html
 themes:
     - miyadaiku.themes.sample.blog

--- a/samples/strip_directory_index/config.yml
+++ b/samples/strip_directory_index/config.yml
@@ -1,0 +1,4 @@
+strip_directory_index: true
+directory_index: index.html
+themes:
+    - miyadaiku.themes.sample.blog

--- a/samples/strip_directory_index/contents/fuga/index.md
+++ b/samples/strip_directory_index/contents/fuga/index.md
@@ -1,0 +1,12 @@
+---
+title: Fuga
+category: CategoryA
+tags:
+    - TagA
+    - TagB
+---
+
+# Fuga
+This is the Fuga page.
+
+[To Piyo](/piyo/)

--- a/samples/strip_directory_index/contents/hoge/index.md
+++ b/samples/strip_directory_index/contents/hoge/index.md
@@ -1,0 +1,11 @@
+---
+title: Hoge
+category: CategoryA
+tags:
+    - TagA
+    - TagB
+---
+
+# Hoge
+This is the Hoge page.
+

--- a/samples/strip_directory_index/contents/index.yml
+++ b/samples/strip_directory_index/contents/index.yml
@@ -1,0 +1,5 @@
+type: index
+indexpage_max_articles: 1
+indexpage_orphan: 0
+indexpage_filename_templ: './index.html'
+indexpage_filename_templ2: './page/{{cur_page}}/index.html'

--- a/samples/strip_directory_index/contents/index_category.yml
+++ b/samples/strip_directory_index/contents/index_category.yml
@@ -1,0 +1,6 @@
+type: index
+groupby: category
+indexpage_max_articles: 1
+indexpage_orphan: 0
+indexpage_group_filename_templ: '{{ content.groupby }}/{{ group_value }}/index.html'
+indexpage_group_filename_templ2: '{{ content.groupby }}/{{ group_value }}/page/{{ cur_page }}/index.html'

--- a/samples/strip_directory_index/contents/index_tag.yml
+++ b/samples/strip_directory_index/contents/index_tag.yml
@@ -1,0 +1,6 @@
+type: index
+groupby: tags
+indexpage_max_articles: 1
+indexpage_orphan: 0
+indexpage_group_filename_templ: '{{ content.groupby }}/{{ group_value }}/index.html'
+indexpage_group_filename_templ2: '{{ content.groupby }}/{{ group_value }}/page/{{ cur_page }}/index.html'

--- a/samples/strip_directory_index/contents/piyo/index.md
+++ b/samples/strip_directory_index/contents/piyo/index.md
@@ -1,0 +1,12 @@
+---
+title: Piyo
+category: CategoryA
+tags:
+    - TagA
+    - TagB
+---
+
+# Piyo
+This is the Piyo page.
+
+[To Fuga](/fuga/)

--- a/tests/test_strip_directory_index.py
+++ b/tests/test_strip_directory_index.py
@@ -1,8 +1,22 @@
 from miyadaiku import strip_directory_index
 
 def test_strip_directory_index():
+    # real cases
     assert strip_directory_index('index.html', 'index.html') == ''
     assert strip_directory_index('hoge.html', 'hoge.html') == ''
     assert strip_directory_index('hoge.html', 'fuga.html') == 'hoge.html'
     assert strip_directory_index('foo/bar.html', 'bar.html') == 'foo/'
     assert strip_directory_index('foo/bar.html', 'foo.html') == 'foo/bar.html'
+
+    # abs path simulation
+    assert strip_directory_index('/index.html', 'index.html') == '/'
+    assert strip_directory_index('/hoge.html', 'fuga.html') == '/hoge.html'
+    assert strip_directory_index('/foo/bar.html', 'bar.html') == '/foo/'
+    assert strip_directory_index('/foo/bar.html', 'foo.html') == '/foo/bar.html'
+
+    # URL simulation
+    assert strip_directory_index('https://example.com/index.html', 'index.html') == 'https://example.com/'
+    assert strip_directory_index('https://example.com/hoge.html', 'hoge.html') == 'https://example.com/'
+    assert strip_directory_index('https://example.com/hoge.html', 'fuga.html') == 'https://example.com/hoge.html'
+    assert strip_directory_index('https://example.com/foo/bar.html', 'bar.html') == 'https://example.com/foo/'
+    assert strip_directory_index('https://example.com/foo/bar.html', 'foo.html') == 'https://example.com/foo/bar.html'

--- a/tests/test_strip_directory_index.py
+++ b/tests/test_strip_directory_index.py
@@ -1,0 +1,8 @@
+from miyadaiku import strip_directory_index
+
+def test_strip_directory_index():
+    assert strip_directory_index('index.html', 'index.html') == ''
+    assert strip_directory_index('hoge.html', 'hoge.html') == ''
+    assert strip_directory_index('hoge.html', 'fuga.html') == 'hoge.html'
+    assert strip_directory_index('foo/bar.html', 'bar.html') == 'foo/'
+    assert strip_directory_index('foo/bar.html', 'foo.html') == 'foo/bar.html'

--- a/tests/test_strip_directory_index.py
+++ b/tests/test_strip_directory_index.py
@@ -9,12 +9,15 @@ def test_strip_directory_index():
     assert strip_directory_index('foo/bar.html', 'foo.html') == 'foo/bar.html'
 
     # abs path simulation
+    assert strip_directory_index('/', 'hoge.html') == '/'
     assert strip_directory_index('/index.html', 'index.html') == '/'
     assert strip_directory_index('/hoge.html', 'fuga.html') == '/hoge.html'
     assert strip_directory_index('/foo/bar.html', 'bar.html') == '/foo/'
     assert strip_directory_index('/foo/bar.html', 'foo.html') == '/foo/bar.html'
 
     # URL simulation
+    assert strip_directory_index('https://example.com', 'hoge.html') == 'https://example.com'
+    assert strip_directory_index('https://example.com/', 'hoge.html') == 'https://example.com/'
     assert strip_directory_index('https://example.com/index.html', 'index.html') == 'https://example.com/'
     assert strip_directory_index('https://example.com/hoge.html', 'hoge.html') == 'https://example.com/'
     assert strip_directory_index('https://example.com/hoge.html', 'fuga.html') == 'https://example.com/hoge.html'


### PR DESCRIPTION
Add properties `strip_directory_index` and `directory_index` to remove a filename from generated URLs used in sitemap and `page.path`.

To see how it works, use a sample `samples/strip_directory_index/` and testcases `tests/test_strip_directory_index.py`.

## Background
The trailing slash feature to remove filenames from generated URL was proposed in #5 and added as an property `canonical_url`.

We can remove filenames to set `canonical_url: ./` in each article page (maybe this is a tricky usage).

But this approach cannot be applied to `type: index` pages because the variables like `cur_page`, `content.groupby`, `group_value` cannot be used in `canonical_url`.

And also, adding `canonical_url: ./` to all desired pages (like daily blog posts) except `type: index` is confusing and annoying.

- Examples
  - Article page path: `contents/2021/slug_of_post/index.md`
    - Current generated URL: `/2021/slug_of_post/index.html`
    - `canonical_url: ./`: `/2021/slug_of_post/`
    - Patched URL: `/2021/slug_of_post/`
  - `type: index` page URL: `/tags/mytag/index.html`
    - Current generated URL: `/mytag/index.html`
    - Patched URL: `/mytag/`
  - Paginated `type: index` URL example: `/tags/mytag/{{ cur_page }}/index.html`
    - Current generated URL: `/mytag/{{ cur_page }}/index.html`
    - Patched URL: `/mytag/{{ cur_page }}/`
  
## Feature: `strip_directory_index`

To enable this feature, add these properties to your `config.yml`(`directory_index` is optional since the default value is `index.html`).

```yaml
strip_directory_index: true
directory_index: index.html
```

## Example: Path to URL conversion table

|Source Path|Current generated URL (`strip_directory_index: false`)|Patched URL (`strip_directory_index: true`)|
|:--|:--|:--|
|contents/index.md|/index.html|/|
|contents/hoge/index.md|/hoge/index.html|/hoge/|
|contents/hoge/fuga/index.md|/hoge/fuga/index.html|/hoge/fuga/|
|-|/tags/hoge/index.html|/tags/hoge/|
|-|/tags/hoge/page/2/index.html|/tags/hoge/page/2/|
